### PR TITLE
thermal: added system temperature sensors

### DIFF
--- a/cmd/gokr-stat/stat.go
+++ b/cmd/gokr-stat/stat.go
@@ -117,7 +117,7 @@ func printStats() error {
 		fmt.Printf(" recv  send | ")
 		if *thermalFlag {
 			fmt.Printf(" used  free  buff  cach | ")
-			fmt.Printf(" tz0\n")
+			fmt.Printf(" cpu\n")
 		} else {
 			fmt.Printf(" used  free  buff  cach\n")
 		}

--- a/internal/statflag/statflag.go
+++ b/internal/statflag/statflag.go
@@ -1,0 +1,38 @@
+package statflag
+
+import (
+	"strings"
+
+	"github.com/gokrazy/stat"
+	"github.com/gokrazy/stat/internal/cpu"
+	"github.com/gokrazy/stat/internal/disk"
+	"github.com/gokrazy/stat/internal/mem"
+	"github.com/gokrazy/stat/internal/net"
+	"github.com/gokrazy/stat/internal/sys"
+	"github.com/gokrazy/stat/internal/thermal"
+)
+
+type ProcessAndFormatter interface {
+	ProcessAndFormat(map[string][]byte) []stat.Col
+}
+
+func ModulesFromFlag(enabledModules string) ([]ProcessAndFormatter, bool) {
+	if strings.Contains(enabledModules, "thermal") {
+		return []ProcessAndFormatter{
+			&cpu.Stats{},
+			&disk.Stats{},
+			&sys.Stats{},
+			&net.Stats{},
+			&mem.Stats{},
+			&thermal.Stats{},
+		}, true
+	} else {
+		return []ProcessAndFormatter{
+			&cpu.Stats{},
+			&disk.Stats{},
+			&sys.Stats{},
+			&net.Stats{},
+			&mem.Stats{},
+		}, false
+	}
+}

--- a/internal/thermal/thermal.go
+++ b/internal/thermal/thermal.go
@@ -8,7 +8,7 @@ import (
 )
 
 type reading struct {
-	thermalZone uint64
+	temp uint64
 }
 
 type Stats struct {
@@ -28,12 +28,12 @@ func (s *Stats) process(contents map[string][]byte) {
 	}
 
 	therm := strings.TrimSpace(line)
-	s.cur.thermalZone = must.Uint64(therm)
+	s.cur.temp = must.Uint64(therm)
 }
 
 func (s *Stats) ProcessAndFormat(contents map[string][]byte) []stat.Col {
 	s.process(contents)
 	return []stat.Col{
-		{Type: stat.ColPercentage, ValFloat64: float64(s.cur.thermalZone) / 1000, Width: 3, Scale: 34},
+		{Type: stat.ColPercentage, ValFloat64: float64(s.cur.temp) / 1000, Width: 3, Scale: 34},
 	}
 }

--- a/internal/thermal/thermal.go
+++ b/internal/thermal/thermal.go
@@ -1,0 +1,39 @@
+package thermal
+
+import (
+	"strings"
+
+	"github.com/gokrazy/stat"
+	"github.com/gokrazy/stat/internal/must"
+)
+
+type reading struct {
+	thermalZone uint64
+}
+
+type Stats struct {
+	cur reading
+}
+
+func (s *Stats) FileContents() []string {
+	return []string{"/sys/class/thermal/thermal_zone0/temp"}
+}
+
+func (s *Stats) process(contents map[string][]byte) {
+	s.cur = reading{}
+
+	line := string(contents["/sys/class/thermal/thermal_zone0/temp"])
+	if len(line) == 0 {
+		return
+	}
+
+	therm := strings.TrimSpace(line)
+	s.cur.thermalZone = must.Uint64(therm)
+}
+
+func (s *Stats) ProcessAndFormat(contents map[string][]byte) []stat.Col {
+	s.process(contents)
+	return []stat.Col{
+		{Type: stat.ColPercentage, ValFloat64: float64(s.cur.thermalZone) / 1000, Width: 3, Scale: 34},
+	}
+}


### PR DESCRIPTION
Related to https://github.com/gokrazy/stat/issues/3
With this is now possible to check the temperature of the pi

Both `stat` and `webstat` work by seting up the flag `-thermal`

- Print while using `stat` with and without the `-thermal` flag

![image](https://github.com/gokrazy/stat/assets/12052283/f29ecbf7-6ebb-4319-ac37-e50e35a3be26)

- Print while using `webstat` with  `-thermal` flag

![image](https://github.com/gokrazy/stat/assets/12052283/f9ef3dd3-4752-41b4-9168-41966cbb8bf5)

@stapelberg tell me what do you think. I didn't implement anything special for the flag handling since this is intended to be simple.
And maybe if this merges we could update the description referring to the `-thermal` flag.
Thanks!

